### PR TITLE
search_songs() raises a "can't convert String into Integer" error

### DIFF
--- a/lib/grooveshark/client.rb
+++ b/lib/grooveshark/client.rb
@@ -76,7 +76,7 @@ module Grooveshark
       
     # Perform search request for query
     def search(type, query)
-      results = request('getSearchResults', {:type => type, :query => query})['songs']
+      results = request('getSearchResults', {:type => type, :query => query})['songs']['songs']
       results.map { |song| Song.new song }
     end
     


### PR DESCRIPTION
I'm not sure if attached commit breaks anything else but it makes search_songs() work again.
### Test code

```
require 'grooveshark'

Grooveshark::Client.new.search_songs("this is a test")
```
### Result

```
$ ruby test.rb
/Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/song.rb:11:in `[]': can't convert String into Integer (TypeError)
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/song.rb:11:in `initialize'
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/client.rb:80:in `new'
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/client.rb:80:in `block in search'
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/client.rb:80:in `each'
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/client.rb:80:in `map'
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/client.rb:80:in `search'
    from /Users/frosas/.rvm/gems/ruby-1.9.2-p290/gems/grooveshark-0.2.2/lib/grooveshark/client.rb:85:in `search_songs'
    from test.rb:3:in `<main>'
```
