### PR TITLE
Fixed the gsConfig issue

### DIFF
--- a/lib/grooveshark/client.rb
+++ b/lib/grooveshark/client.rb
@@ -101,7 +101,7 @@ module Grooveshark
       config_json = preload_response.to_s.scan(/window.tokenData = (.*);/).flatten.first
       raise GeneralError, "gsConfig not found" if not config_json
       config = JSON.parse(config_json)['getGSConfig']
-      [session, config['country']['ID']]
+      [session, config['country']]
     end
     
     # Get communication token


### PR DESCRIPTION
i didn't use the session id in the new "getGSConfig" because the old way of getting the session id seems to be working fine, but i'm not sure if it would be preferable to get it all from getGSConfig. it should also be noted that (was it like this before?) the communication token is also included with the preloaded json, but posting for that still seems functional as well.
