### PR TITLE
Remove rubocop for 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ rvm:
   - 1.9.3
   - 2.0
   - 2.1
+
+script:
+  - bundle exec rake spec
+  - sh -c "if [ \"$TRAVIS_RUBY_VERSION\" != '1.9.2' ]; then bundle exec rake rubocop; fi"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Grooveshark API
+# Grooveshark API [![Build Status](https://travis-ci.org/sosedoff/grooveshark.svg?branch=master)](https://travis-ci.org/sosedoff/grooveshark)
 
 Unofficial grooveshark API ruby library gives your ability to search and stream songs,
 manage playlists, media library and favorites.
@@ -244,7 +244,7 @@ user.feed
 Run test suite:
 
 ```
-rake test
+bundle exec rake
 ```
 
 ## Contact

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
 require 'bundler'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new(:rubocop)
+begin
+  require 'rubocop/rake_task'
+
+  RuboCop::RakeTask.new(:rubocop)
+rescue LoadError
+  puts 'Rubocop is needed to run this task.'
+end
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/*_spec.rb'

--- a/grooveshark.gemspec
+++ b/grooveshark.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '~>0.6'
   s.add_development_dependency 'rspec', '~>3.0'
   s.add_development_dependency 'simplecov', '~>0.9'
-  s.add_development_dependency 'rubocop', '~>0.25'
   s.add_development_dependency 'fakefs', '~>0.5'
+
+  s.add_development_dependency 'rubocop', '~>0.25' if RUBY_VERSION != '1.9.2'
 end


### PR DESCRIPTION
- 1.9.2 is not suppoted by rubocop
- Add travis badge in README file
- Change command for runnning test in README file
